### PR TITLE
Feature/add config setters

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -65,10 +65,10 @@ func generateConfig(projectName, airflowHome string) string {
 	}
 
 	config := ComposeConfig{
-		PostgresUser:         config.GetString(config.CFGPostgresUser),
-		PostgresPassword:     config.GetString(config.CFGPostgresPassword),
-		PostgresHost:         config.GetString(config.CFGPostgresHost),
-		PostgresPort:         config.GetString(config.CFGPostgresPort),
+		PostgresUser:         config.CFG.PostgresUser.GetString(),
+		PostgresPassword:     config.CFG.PostgresPassword.GetString(),
+		PostgresHost:         config.CFG.PostgresHost.GetString(),
+		PostgresPort:         config.CFG.PostgresPort.GetString(),
 		AirflowImage:         imageName(projectName, "latest"),
 		AirflowHome:          airflowHome,
 		AirflowUser:          "astro",
@@ -104,7 +104,7 @@ func createProjectFromContext(projectName, airflowHome string) (project.APIProje
 // Start starts a local airflow development cluster
 func Start(airflowHome string) error {
 	// Get project name from config
-	projectName := config.GetString(config.CFGProjectName)
+	projectName := config.CFG.ProjectName.GetString()
 
 	// Create a libcompose project
 	project, err := createProjectFromContext(projectName, airflowHome)
@@ -127,7 +127,7 @@ func Start(airflowHome string) error {
 // Stop stops a local airflow development cluster
 func Stop(airflowHome string) error {
 	// Get project name from config
-	projectName := config.GetString(config.CFGProjectName)
+	projectName := config.CFG.ProjectName.GetString()
 
 	// Create a libcompose project
 	project, err := createProjectFromContext(projectName, airflowHome)
@@ -147,7 +147,7 @@ func Stop(airflowHome string) error {
 // PS prints the running airflow containers
 func PS(airflowHome string) error {
 	// Get project name from config
-	projectName := config.GetString(config.CFGProjectName)
+	projectName := config.CFG.ProjectName.GetString()
 
 	// Create a libcompose project
 	project, err := createProjectFromContext(projectName, airflowHome)
@@ -218,7 +218,7 @@ func Deploy(path, name string) error {
 	// Tag our build with remote registry and incremented tag
 	tag := fmt.Sprintf("%s%d", deployTagPrefix, highestTag+1)
 	remoteImage := fmt.Sprintf("%s/%s",
-		config.GetString(config.CFGRegistryAuthority), imageName(name, tag))
+		config.CFG.RegistryAuthority.GetString(), imageName(name, tag))
 	docker.Exec("tag", deployImage, remoteImage)
 
 	// Push image to registry

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -7,10 +7,10 @@ import (
 
 // Login logs a user into the docker registry. Will need to login to Houston next.
 func Login() {
-	docker.Exec("login", config.GetString(config.CFGRegistryAuthority))
+	docker.Exec("login", config.CFG.RegistryAuthority.GetString())
 }
 
 // Logout logs a user out of the docker registry. Will need to logout of Houston next.
 func Logout() {
-	docker.Exec("logout", config.GetString(config.CFGRegistryAuthority))
+	docker.Exec("logout", config.CFG.RegistryAuthority.GetString())
 }

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -129,7 +129,7 @@ func airflowInit(cmd *cobra.Command, args []string) error {
 	if !exists {
 		config.CreateProjectConfig(path)
 	}
-	config.SetProjectString(config.CFGProjectName, projectName)
+	config.CFG.ProjectName.SetProjectString(projectName)
 	airflow.Init(path)
 
 	if exists {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/astronomerio/astro-cli/config"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	configRootCmd = &cobra.Command{
+		Use:   "config",
+		Short: "Manage astro project configurations",
+		Long:  "Manage astro project configurations",
+	}
+
+	configGetCmd = &cobra.Command{
+		Use:   "get",
+		Short: "Get astro project configuration",
+		Long:  "Get astro project configuration",
+		RunE:  configGet,
+		// TODO add arg validator
+		// TODO check project specific config
+	}
+
+	configSetCmd = &cobra.Command{
+		Use:   "set",
+		Short: "Set astro project configuration",
+		Long:  "Set astro project configuration",
+		RunE:  configSet,
+		// TODO add arg validator
+		// TODO check project specific config
+	}
+)
+
+func init() {
+	// Set up project root
+	projectRoot, _ = config.ProjectRoot()
+
+	// Config root
+	RootCmd.AddCommand(configRootCmd)
+
+	// Config get
+	configRootCmd.AddCommand(configGetCmd)
+	// Config set
+	configRootCmd.AddCommand(configSetCmd)
+}
+
+func configGet(command *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("Must specify config key")
+	}
+	// get config struct
+	cfg, ok := config.CFGStrMap[args[0]]
+	if !ok {
+		return errors.New("Config does not exist, check your config key")
+	}
+
+	if !cfg.Gettable {
+		errMsg := fmt.Sprintf("Config %s is not gettable", cfg.Path)
+		return errors.New(errMsg)
+	}
+
+	fmt.Printf("%s: %s\n", cfg.Path, cfg.GetString())
+
+	return nil
+}
+
+func configSet(command *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return errors.New("Must specify exactly two arguments (key value) when setting a config")
+	}
+
+	// get config struct
+	cfg, ok := config.CFGStrMap[args[0]]
+
+	if !ok {
+		return errors.New("Config does not exist, check your config key")
+	}
+
+	if !cfg.Settable {
+		errMsg := fmt.Sprintf("Config %s is not settable", cfg.Path)
+		return errors.New(errMsg)
+	}
+
+	cfg.SetProjectString(args[1])
+
+	fmt.Printf("Setting %s to %s successfully\n", cfg.Path, args[1])
+	return nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -195,8 +195,18 @@ func ProjectRoot() (string, error) {
 // GetString will return the requested config, check working dir and fallback to home
 func GetString(config string) string {
 	if configExists(viperProject) && viperProject.IsSet(config) {
-		return viperProject.GetString(config)
+		return GetHomeString(config)
 	}
+	return GetHomeString(config)
+}
+
+// GetProjectString will return a project config
+func GetProjectString(config string) string {
+	return viperProject.GetString(config)
+}
+
+// GetHomeString will return config from home string
+func GetHomeString(config string) string {
 	return viperHome.GetString(config)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -20,28 +20,25 @@ var (
 	// ConfigDir is the directory for astro files
 	ConfigDir = ".astro"
 
-	// CFGPostgresUser is the default postgres user
-	CFGPostgresUser = "postgres.user"
-	// CFGPostgresPassword is the default postgres password
-	CFGPostgresPassword = "postgres.password"
-	// CFGPostgresHost is the default postgres host
-	CFGPostgresHost = "postgres.host"
-	// CFGPostgresPort is the default postgres port
-	CFGPostgresPort = "postgres.port"
-	// CFGRegistryAuthority is the default docker registry
-	CFGRegistryAuthority = "docker.registry.authority"
-	// CFGRegistryUser is the default docker registry
-	CFGRegistryUser = "docker.registry.user"
-	// CFGRegistryPassword is the default docker registry
-	CFGRegistryPassword = "docker.registry.password"
-
-	// CFGProjectName is the name of a project
-	CFGProjectName = "project.name"
-
 	// HomeConfigPath is the path to the users global directory
 	HomeConfigPath = filepath.Join(utils.GetHomeDir(), ConfigDir)
 	// HomeConfigFile is the global config file
 	HomeConfigFile = filepath.Join(HomeConfigPath, ConfigFileNameWithExt)
+
+	// CFGStrMap maintains string to cfg mapping
+	CFGStrMap = make(map[string]cfg)
+
+	// CFG Houses configuration meta
+	CFG = cfgs{
+		PostgresUser:      initCfg("postgres.user", true, true),
+		PostgresPassword:  initCfg("postgres.password", true, true),
+		PostgresHost:      initCfg("postgres.host", true, true),
+		PostgresPort:      initCfg("postgres.port", true, true),
+		RegistryAuthority: initCfg("docker.registry.authority", true, true),
+		RegistryUser:      initCfg("docker.registry.user", true, true),
+		RegistryPassword:  initCfg("docker.registry.password", true, true),
+		ProjectName:       initCfg("project.name", true, true),
+	}
 
 	// viperHome is the viper object in the users home directory
 	viperHome *viper.Viper
@@ -55,6 +52,12 @@ func InitConfig() {
 	initProject()
 }
 
+func initCfg(path string, gettable bool, settable bool) cfg {
+	cfg := cfg{path, gettable, settable}
+	CFGStrMap[path] = cfg
+	return cfg
+}
+
 // Init viper for config file in home directory
 func initHome() {
 	viperHome = viper.New()
@@ -63,14 +66,14 @@ func initHome() {
 	viperHome.SetConfigFile(HomeConfigFile)
 
 	// Set defaults
-	viperHome.SetDefault(CFGPostgresUser, "postgres")
-	viperHome.SetDefault(CFGPostgresPassword, "postgres")
-	viperHome.SetDefault(CFGPostgresHost, "postgres")
-	viperHome.SetDefault(CFGPostgresPort, "5432")
+	viperHome.SetDefault(CFG.PostgresUser.Path, "postgres")
+	viperHome.SetDefault(CFG.PostgresPassword.Path, "postgres")
+	viperHome.SetDefault(CFG.PostgresHost.Path, "postgres")
+	viperHome.SetDefault(CFG.PostgresPort.Path, "5432")
 	// XXX: Change default to hosted cloud, allow to be set by user for EE
-	viperHome.SetDefault(CFGRegistryAuthority, "registry.gcp.astronomer.io")
-	viperHome.SetDefault(CFGRegistryUser, "admin")
-	viperHome.SetDefault(CFGRegistryPassword, "admin")
+	viperHome.SetDefault(CFG.RegistryAuthority.Path, "registry.gcp.astronomer.io")
+	viperHome.SetDefault(CFG.RegistryUser.Path, "admin")
+	viperHome.SetDefault(CFG.RegistryPassword.Path, "admin")
 
 	// If home config does not exist, create it
 	if !utils.Exists(HomeConfigFile) {
@@ -157,24 +160,6 @@ func CreateConfig(v *viper.Viper, path, file string) error {
 	return saveConfig(v, file)
 }
 
-// SetHomeString sets a string value in home config
-func SetHomeString(config, value string) {
-	if !configExists(viperHome) {
-		return
-	}
-	viperHome.Set(config, value)
-	saveConfig(viperHome, HomeConfigFile)
-}
-
-// SetProjectString sets a string value in project config
-func SetProjectString(config, value string) {
-	if !configExists(viperProject) {
-		return
-	}
-	viperProject.Set(config, value)
-	saveConfig(viperProject, viperProject.ConfigFileUsed())
-}
-
 // ProjectConfigExists returns a boolean indicating if a project config file exists
 func ProjectConfigExists() bool {
 	return configExists(viperProject)
@@ -190,24 +175,6 @@ func ProjectRoot() (string, error) {
 		return "", nil
 	}
 	return filepath.Dir(configPath), nil
-}
-
-// GetString will return the requested config, check working dir and fallback to home
-func GetString(config string) string {
-	if configExists(viperProject) && viperProject.IsSet(config) {
-		return GetHomeString(config)
-	}
-	return GetHomeString(config)
-}
-
-// GetProjectString will return a project config
-func GetProjectString(config string) string {
-	return viperProject.GetString(config)
-}
-
-// GetHomeString will return config from home string
-func GetHomeString(config string) string {
-	return viperHome.GetString(config)
 }
 
 // saveConfig will save the config to a file

--- a/config/meta.go
+++ b/config/meta.go
@@ -1,0 +1,56 @@
+package config
+
+// cfg defines settings a single configuration setting can have
+type cfg struct {
+	Path     string
+	Gettable bool
+	Settable bool
+}
+
+// cfgs houses all configurations for an astro project
+type cfgs struct {
+	PostgresUser      cfg
+	PostgresPassword  cfg
+	PostgresHost      cfg
+	PostgresPort      cfg
+	RegistryAuthority cfg
+	RegistryUser      cfg
+	RegistryPassword  cfg
+	ProjectName       cfg
+}
+
+// SetHomeString sets a string value in home config
+func (c cfg) SetHomeString(value string) {
+	if !configExists(viperHome) {
+		return
+	}
+	viperHome.Set(c.Path, value)
+	saveConfig(viperHome, HomeConfigFile)
+}
+
+// SetProjectString sets a string value in project config
+func (c cfg) SetProjectString(value string) {
+	if !configExists(viperProject) {
+		return
+	}
+	viperProject.Set(c.Path, value)
+	saveConfig(viperProject, viperProject.ConfigFileUsed())
+}
+
+// GetString will return the requested config, check working dir and fallback to home
+func (c cfg) GetString() string {
+	if configExists(viperProject) && viperProject.IsSet(c.Path) {
+		return c.GetProjectString()
+	}
+	return c.GetHomeString()
+}
+
+// GetProjectString will return a project config
+func (c cfg) GetProjectString() string {
+	return viperProject.GetString(c.Path)
+}
+
+// GetHomeString will return config from home string
+func (c cfg) GetHomeString() string {
+	return viperHome.GetString(c.Path)
+}

--- a/docker/registry.go
+++ b/docker/registry.go
@@ -17,9 +17,9 @@ type ListRepositoryTagsResponse struct {
 
 // ListRepositoryTags lists the tags for a given repository
 func ListRepositoryTags(repository string) ([]string, error) {
-	registry := config.GetString(config.CFGRegistryAuthority)
-	user := config.GetString(config.CFGRegistryUser)
-	password := config.GetString(config.CFGRegistryPassword)
+	registry := config.CFG.RegistryAuthority.GetString()
+	user := config.CFG.RegistryUser.GetString()
+	password := config.CFG.RegistryPassword.GetString()
 
 	// Get an HTTP Client
 	client := &http.Client{}


### PR DESCRIPTION
This PR
- adds ability to get and set configs from CLI
- changes project configs from strings to struct repr of configs. This allows
    - dot notation access to cfgs
    - properties to be stored inline with cfg ie
        - gettable bool
        - settable bool
        - projectAccessible
        - etc.
- closes #22 