### PR TITLE
remove meta scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Write metadata"
-          command: |
-            if [ "${CIRCLE_TAG}" != "" ]; then
-              sh ./.circleci/scripts/write_metadata.sh $CIRCLE_TAG "`date '+%B %d, %Y @ %H:%M:%S'`"
-            else
-              echo "Not tagged, skipping step"
-            fi
-      - run:
           name: "Install Goreleaser"
           command: |
             if [ "${CIRCLE_TAG}" != "" ]; then

--- a/.circleci/scripts/write_metadata.sh
+++ b/.circleci/scripts/write_metadata.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-VERSION=$1
-BUILD_DATE="`date '+%B %d, %Y @ %H:%M:%S'`"
-CONTENT="package meta\n\nvar VERSION = \"$VERSION\"\nvar BUILD_DATE = \"$BUILD_DATE\""
-
-mkdir -p meta
-
-printf "$CONTENT" > ./meta/meta.go


### PR DESCRIPTION
Meta scripts are breaking build as goreleaser expects a clean commit history - Need to discuss whether we should be pushing commits in a build process as well as the original intention of the meta scripts.