### PR TITLE
check for non-200 status code on registry request

### DIFF
--- a/docker/registry.go
+++ b/docker/registry.go
@@ -34,7 +34,19 @@ func ListRepositoryTags(repository string) ([]string, error) {
 
 	// Make the request
 	resp, reqErr := client.Do(req)
-	if reqErr != nil {
+	// TODO Remove config suggestion and 401 check once houston is handling auth
+	if resp.StatusCode == 401 {
+
+		fmt.Println(`Failed to authenticate to registry
+
+You can set your registry auth using
+	astro config set docker.registry.user [registry_user] -g
+	astro config set docker.registry.password [registry_password] -g
+	`)
+		return []string{}, errors.New("")
+	}
+
+	if reqErr != nil || resp.StatusCode != 200 {
 		return []string{}, errors.Wrap(reqErr, "Error requesting repositories")
 	}
 

--- a/docker/registry.go
+++ b/docker/registry.go
@@ -34,20 +34,21 @@ func ListRepositoryTags(repository string) ([]string, error) {
 
 	// Make the request
 	resp, reqErr := client.Do(req)
+
+	if reqErr != nil {
+		return []string{}, errors.Wrap(reqErr, "Error requesting repositories")
+	}
+
 	// TODO Remove config suggestion and 401 check once houston is handling auth
 	if resp.StatusCode == 401 {
 
 		fmt.Println(`Failed to authenticate to registry
-
-You can set your registry auth using
-	astro config set docker.registry.user [registry_user] -g
-	astro config set docker.registry.password [registry_password] -g
-	`)
+	
+	You can set your registry auth using
+		astro config set docker.registry.user [registry_user] -g
+		astro config set docker.registry.password [registry_password] -g
+		`)
 		return []string{}, errors.New("")
-	}
-
-	if reqErr != nil || resp.StatusCode != 200 {
-		return []string{}, errors.Wrap(reqErr, "Error requesting repositories")
 	}
 
 	// Close body reader


### PR DESCRIPTION
This pr
 - throws an error on all non-200 status codes
 - adds temporary fix for silent 401 errors when attempting to deploy to a registry with unset auth configs.

The temporary fix can be removed as soon as houston is handling auth to registry