### PR TITLE
Capture and pass auth to docker login

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,13 +1,30 @@
 package auth
 
 import (
+	"fmt"
+
 	"github.com/astronomerio/astro-cli/config"
 	"github.com/astronomerio/astro-cli/docker"
+	"github.com/astronomerio/astro-cli/utils"
 )
 
 // Login logs a user into the docker registry. Will need to login to Houston next.
 func Login() {
-	docker.Exec("login", config.CFG.RegistryAuthority.GetString())
+	registry := config.CFG.RegistryAuthority.GetString()
+	username := utils.InputText("Username: ")
+	password, _ := utils.InputPassword("Password: ")
+
+	err := docker.ExecLogin(registry, username, password)
+	if err != nil {
+		// Println instead of panic to prevent excessive error logging to
+		// stdout on a failed login
+		fmt.Println(err)
+		return
+	}
+
+	// pass successful credentials to config
+	config.CFG.RegistryUser.SetProjectString(username)
+	config.CFG.RegistryPassword.SetProjectString(password)
 }
 
 // Logout logs a user out of the docker registry. Will need to logout of Houston next.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -16,8 +16,7 @@ func Login() {
 
 	err := docker.ExecLogin(registry, username, password)
 	if err != nil {
-		// Println instead of panic to prevent excessive error logging to
-		// stdout on a failed login
+		// Println instead of panic to prevent excessive error logging to stdout on a failed login
 		fmt.Println(err)
 		return
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -37,7 +37,7 @@ func ExecLogin(registry, username, password string) error {
 	}
 
 	loginCmd := fmt.Sprintf("echo '%s' | docker login %s -u %s --password-stdin", password, registry, username)
-	cmd := exec.Command("bash", "-c", loginCmd)
+	cmd := exec.Command("/usr/bin/env", "sh", "-c", loginCmd)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 )
@@ -25,4 +26,22 @@ func Exec(args ...string) {
 	if cmdErr := cmd.Run(); cmdErr != nil {
 		panic(cmdErr)
 	}
+}
+
+// ExecLogin executes a docker login
+// Is a workaround for submitting password to stdin without prompting user again
+func ExecLogin(registry, username, password string) error {
+	_, lookErr := exec.LookPath(Docker)
+	if lookErr != nil {
+		panic(lookErr)
+	}
+
+	loginCmd := fmt.Sprintf("echo '%s' | docker login %s -u %s --password-stdin", password, registry, username)
+	cmd := exec.Command("bash", "-c", loginCmd)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }

--- a/utils/input.go
+++ b/utils/input.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// InputText requests a user for input text and returns it
+func InputText(promptText string) string {
+	reader := bufio.NewReader(os.Stdin)
+	if promptText != "" {
+		fmt.Print(promptText)
+	}
+	text, _ := reader.ReadString('\n')
+	return strings.Trim(text, "\r\n")
+}
+
+// InputPassword requests a users passord, does not print out what they entered, and returns it
+func InputPassword(promptText string) (string, error) {
+	fmt.Print(promptText)
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	fmt.Print("\n")
+	return string(bytePassword), nil
+}
+
+// InputConfirm requests a user to confirm their input
+func InputConfirm(promptText string) (bool, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s (y/n) ", promptText)
+
+	text, _ := reader.ReadString('\n')
+	return strings.Trim(text, "\r\n") == "y", nil
+}


### PR DESCRIPTION
This commit allows for us to capture credentials in the same command we auth to the private registry. It paves the way for a single auth command to login to houston and the registry