### PR TITLE
Check for uncommited changes before deploy

### DIFF
--- a/airflow/docker.go
+++ b/airflow/docker.go
@@ -237,7 +237,6 @@ func PS(airflowHome string) error {
 }
 
 // Deploy pushes a new docker image
-// TODO: Check for uncommitted git changes
 func Deploy(path, name string) error {
 	// Get a list of tags in the repository for this image
 	tags, err := docker.ListRepositoryTags(repositoryName(name))

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -12,6 +12,7 @@ import (
 var (
 	projectRoot string
 	projectName string
+	forceDeploy bool
 
 	airflowRootCmd = &cobra.Command{
 		Use:   "airflow",
@@ -91,6 +92,7 @@ func init() {
 
 	// Airflow deploy
 	airflowRootCmd.AddCommand(airflowDeployCmd)
+	airflowDeployCmd.Flags().BoolVarP(&forceDeploy, "force-deploy", "f", false, "Force deploy if uncommited changes")
 
 	// Airflow start
 	airflowRootCmd.AddCommand(airflowStartCmd)
@@ -122,6 +124,11 @@ func airflowCreate(cmd *cobra.Command, args []string) error {
 }
 
 func airflowDeploy(cmd *cobra.Command, args []string) error {
+	if utils.HasUncommitedChanges() && !forceDeploy {
+		fmt.Println("Project directory has uncommmited changes, use `astro airflow deploy [releaseName] -f` to force deploy.")
+		return nil
+	}
+
 	return airflow.Deploy(projectRoot, args[0])
 }
 

--- a/cmd/airflow.go
+++ b/cmd/airflow.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/astronomerio/astro-cli/airflow"
 	"github.com/astronomerio/astro-cli/config"
+	"github.com/astronomerio/astro-cli/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -92,7 +93,7 @@ func init() {
 
 	// Airflow deploy
 	airflowRootCmd.AddCommand(airflowDeployCmd)
-	airflowDeployCmd.Flags().BoolVarP(&forceDeploy, "force-deploy", "f", false, "Force deploy if uncommited changes")
+	airflowDeployCmd.Flags().BoolVarP(&forceDeploy, "force", "f", false, "Force deploy if uncommited changes")
 
 	// Airflow start
 	airflowRootCmd.AddCommand(airflowStartCmd)

--- a/utils/git.go
+++ b/utils/git.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"os/exec"
+)
+
+// IsGitRepository checks if current directory is a git respository
+func IsGitRepository() bool {
+	_, err := exec.Command("git", "rev-parse", "--is-inside-working-tree").Output()
+	if err != nil {
+		return false
+	}
+
+	return true
+
+}
+
+// HasUncommitedChanges checks repository for uncommited changes
+func HasUncommitedChanges() bool {
+	if IsGitRepository() {
+		// There is no system indepdendent way to get exit code
+		// so we treat all exit codes the same, this works as long as we check IsGitRepository first
+		_, err := exec.Command("git", "diff", "--quiet", "HEAD").Output()
+		if err != nil {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
- closes #13 
- checks if git repo has been init'd
- then checks if there are uncommitted changes
- adds -f flag to `astro airflow deploy` to force a deploy if there are uncommitted changes