### PR TITLE
Prevent dir walking when searching for a project

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	oAuthOnly bool
+	domain    string
 
 	authRootCmd = &cobra.Command{
 		Use:   "auth",
@@ -44,8 +45,6 @@ func init() {
 }
 
 func authLogin(cmd *cobra.Command, args []string) error {
-	var domain string
-
 	if len(args) == 1 {
 		domain = args[0]
 	}
@@ -59,8 +58,6 @@ func authLogin(cmd *cobra.Command, args []string) error {
 }
 
 func authLogout(cmd *cobra.Command, args []string) {
-	var domain string
-
 	if len(args) == 1 {
 		domain = args[0]
 	} else {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,9 +38,6 @@ var (
 )
 
 func init() {
-	// Set up project root
-	projectRoot, _ = config.ProjectRoot()
-
 	// Config root
 	RootCmd.AddCommand(configRootCmd)
 	configRootCmd.PersistentFlags().BoolVarP(&globalFlag, "global", "g", false, "view or modify global config")
@@ -53,7 +50,7 @@ func init() {
 }
 
 func ensureGlobalFlag(cmd *cobra.Command, args []string) {
-	if !(len(projectRoot) > 0) && !globalFlag {
+	if !config.IsProjectDir(config.WorkingPath) && !globalFlag {
 		var c = "astro config " + cmd.Use + " " + args[0] + " -g"
 		fmt.Printf(messages.CONFIG_USE_OUTSIDE_PROJECT_DIR, cmd.Use, cmd.Use, c)
 		os.Exit(1)

--- a/config/config.go
+++ b/config/config.go
@@ -21,10 +21,15 @@ var (
 	// ConfigDir is the directory for astro files
 	ConfigDir = ".astro"
 
-	// HomeConfigPath is the path to the users global directory
-	HomeConfigPath = filepath.Join(fileutil.GetHomeDir(), ConfigDir)
+	// HomePath is the path to a users home directory
+	HomePath = fileutil.GetHomeDir()
+	// HomeConfigPath is the path to the users global config directory
+	HomeConfigPath = filepath.Join(HomePath, ConfigDir)
 	// HomeConfigFile is the global config file
 	HomeConfigFile = filepath.Join(HomeConfigPath, ConfigFileNameWithExt)
+
+	// WorkingPath is the path to the working directory
+	WorkingPath = fileutil.GetWorkingDir()
 
 	// CFGStrMap maintains string to cfg mapping
 	CFGStrMap = make(map[string]cfg)
@@ -96,22 +101,18 @@ func initProject() {
 	viperProject.SetConfigName(ConfigFileName)
 	viperProject.SetConfigType(ConfigFileType)
 
-	configPath, searchErr := fileutil.FindDirInPath(ConfigDir)
-	if searchErr != nil {
-		fmt.Printf(messages.CONFIG_SEARCH_ERROR+"\n", searchErr)
-		return
-	}
-
 	// Construct the path to the config file
-	projectConfigFile := filepath.Join(configPath, ConfigFileNameWithExt)
+	workingConfigPath := filepath.Join(WorkingPath, ConfigDir)
+
+	workingConfigFile := filepath.Join(workingConfigPath, ConfigFileNameWithExt)
 
 	// If path is empty or config file does not exist, just return
-	if len(configPath) == 0 || configPath == HomeConfigPath || !fileutil.Exists(projectConfigFile) {
+	if len(workingConfigPath) == 0 || workingConfigPath == HomeConfigPath || !fileutil.Exists(workingConfigFile) {
 		return
 	}
 
 	// Add the path we discovered
-	viperProject.SetConfigFile(projectConfigFile)
+	viperProject.SetConfigFile(workingConfigFile)
 
 	// Read in project config
 	readErr := viperProject.ReadInConfig()
@@ -162,6 +163,8 @@ func ProjectConfigExists() bool {
 }
 
 // ProjectRoot returns the path to the nearest project root
+// TODO Deprecate if remains unused, removed due to
+// https://github.com/astronomerio/astro-cli/issues/103
 func ProjectRoot() (string, error) {
 	configPath, searchErr := fileutil.FindDirInPath(ConfigDir)
 	if searchErr != nil {
@@ -171,6 +174,19 @@ func ProjectRoot() (string, error) {
 		return "", nil
 	}
 	return filepath.Dir(configPath), nil
+}
+
+// IsProjectDir returns a boolean depending on if path is a valid project dir
+func IsProjectDir(path string) bool {
+	configPath := filepath.Join(path, ConfigDir)
+	configFile := filepath.Join(configPath, ConfigFileNameWithExt)
+
+	// Home directory is not a project directory
+	if HomePath == path {
+		return false
+	}
+
+	return fileutil.Exists(configFile)
 }
 
 // saveConfig will save the config to a file

--- a/pkg/fileutil/paths.go
+++ b/pkg/fileutil/paths.go
@@ -2,6 +2,7 @@ package fileutil
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -30,6 +31,8 @@ func GetHomeDir() string {
 }
 
 // FindDirInPath walks up the current directory looking for the .astro folder
+// TODO Deprecate if remains unused, removed due to
+// https://github.com/astronomerio/astro-cli/issues/103
 func FindDirInPath(search string) (string, error) {
 	// Start in our current directory
 	workingDir := GetWorkingDir()
@@ -59,4 +62,20 @@ func FindDirInPath(search string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// IsEmptyDir checks if path is an empty dir
+func IsEmptyDir(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Println(err)
+		return false
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1) // Or f.Readdir(1)
+	if err == io.EOF {
+		return true
+	}
+	return false // Either not empty or error, suits both cases
 }


### PR DESCRIPTION
This ended up being more re-work than expected as `projectRoot` was always looking in the curr dir and walking upwards towards usr root dir if config not found. All walking of dirs has been removed in favor of commands that need a config being run directly out of a project root.

- closes #103
- adds prompt on `astro init` if user is in non-empty directory
- removes the upward walking of a dir if user is not in an immediate project dir (defined by existence of config)