### PR TITLE
Feature/improve tab print

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,19 +1,21 @@
 package cluster
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/astronomerio/astro-cli/config"
+	"github.com/astronomerio/astro-cli/pkg/printutil"
 )
 
-// List all available clusters a user has previously
-// authenticated to
+// List all available clusters a user has previously authenticated to
 // Returns error
 func List() error {
-	r := "  %-44s"
-	colorFmt := "\033[33;m"
-	colorTrm := "\033[0m"
+	tab := printutil.Table{
+		Padding:      []int{44},
+		Header:       []string{"NAME"},
+		ColorRowCode: [2]string{"\033[33;m", "\033[0m"},
+	}
+
 	var domain string
 
 	c, err := GetClusters()
@@ -26,8 +28,6 @@ func List() error {
 		return err
 	}
 
-	h := fmt.Sprintf(r, "NAME")
-	fmt.Println(h)
 	for k, v := range c.Contexts {
 		if v.Domain != "" {
 			domain = v.Domain
@@ -35,14 +35,14 @@ func List() error {
 			domain = strings.Replace(k, "_", ".", -1)
 		}
 
-		fullStr := fmt.Sprintf(r, domain)
 		if domain == ctx.Domain {
-			fullStr = colorFmt + fullStr + colorTrm
+			tab.AddRow([]string{domain}, true)
+		} else {
+			tab.AddRow([]string{domain}, false)
 		}
-
-		fmt.Println(fullStr)
-
 	}
+
+	tab.Print()
 
 	return nil
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -90,6 +90,6 @@ func Switch(domain string) error {
 	if err != nil {
 		return err
 	}
-	config.PrintCurrentContext()
+
 	return nil
 }

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -49,7 +49,11 @@ var (
 		Aliases: []string{"up"},
 		Short:   "Update airflow deployments",
 		Long:    "Update airflow deployments",
+		Example: "\n\tastro deployment update UUID label=Production-Airflow",
 		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) <= 0 {
+				return errors.New("must specify a deployment ID and at least one attribute to update.")
+			}
 			return updateArgValidator(args[1:], deploymentUpdateAttrs)
 		},
 		RunE: deploymentUpdate,

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -58,6 +58,9 @@ var (
 		Short:   "Update an Astronomer workspace",
 		Long:    "Update a workspace name, as well as users and roles assigned to a workspace",
 		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) <= 1 {
+				return errors.New("must specify a workspace ID and at least one attribute to update.")
+			}
 			return updateArgValidator(args[1:], workspaceUpdateAttrs)
 		},
 		RunE: workspaceUpdate,
@@ -131,7 +134,7 @@ func workspaceCreate(cmd *cobra.Command, args []string) error {
 func workspaceList(cmd *cobra.Command, args []string) error {
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	
+
 	return workspace.List()
 }
 
@@ -150,7 +153,7 @@ func workspaceUpdate(cmd *cobra.Command, args []string) error {
 
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	
+
 	return workspace.Update(args[0], argsMap)
 }
 
@@ -176,7 +179,7 @@ func workspaceUserRm(cmd *cobra.Command, args []string) error {
 
 	// Silence Usage as we have now validated command input
 	cmd.SilenceUsage = true
-	
+
 	return workspace.Remove(ws, args[0])
 }
 

--- a/config/context.go
+++ b/config/context.go
@@ -4,6 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/astronomerio/astro-cli/pkg/printutil"
+)
+
+var (
+	tab = printutil.Table{
+		Padding: []int{36, 36},
+		Header:  []string{"CLUSTER", "WORKSPACE"},
+	}
 )
 
 // Contexts holds all available Context structs in a map
@@ -49,9 +58,8 @@ func (c Context) PrintContext() error {
 		workspace = "N/A"
 	}
 
-	r := "%-36s %-36s\n"
-	fmt.Printf(r, "CLUSTER", "WORKSPACE")
-	fmt.Printf(r, cluster, workspace)
+	tab.AddRow([]string{cluster, workspace}, false)
+	tab.Print()
 
 	return nil
 }
@@ -158,10 +166,17 @@ func (c Context) SetContextKey(key, value string) error {
 
 // SwitchContext sets the current config context to the one matching the provided Context struct
 func (c Context) SwitchContext() error {
-	if c.ContextExists() {
+	co, err := c.GetContext()
+	if err != nil {
+		return err
+	} else {
 		viperHome.Set("context", c.Domain)
 		saveConfig(viperHome, HomeConfigFile)
 	}
+
+	tab.AddRow([]string{co.Domain, co.Workspace}, false)
+	tab.SuccessMsg = "\n Switched cluster"
+	tab.Print()
 
 	return nil
 }

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/astronomerio/astro-cli/messages"
 	"github.com/astronomerio/astro-cli/pkg/httputil"
 	"github.com/astronomerio/astro-cli/pkg/jsonstr"
+	"github.com/astronomerio/astro-cli/pkg/printutil"
 )
 
 var (
@@ -57,11 +58,6 @@ func List(ws string, all bool) error {
 	var deployments []houston.Deployment
 	var err error
 
-	r := "  %-30s %-50s %-50s %-50s"
-	h := fmt.Sprintf(r, "NAME", "RELEASE NAME", "DEPLOYMENT ID", "WORKSPACE")
-	// colorFmt := "\033[33;m"
-	// colorTrm := "\033[0m"
-
 	if all {
 		deployments, err = api.GetAllDeployments()
 		if err != nil {
@@ -74,15 +70,22 @@ func List(ws string, all bool) error {
 		}
 	}
 
-	fmt.Println(h)
+	tab := printutil.Table{
+		Padding: []int{30, 50, 50, 50},
+		Header:  []string{"NAME", "RELEASE NAME", "DEPLOYMENT ID", "WORKSPACE"},
+	}
 
+	// Build rows
 	for _, d := range deployments {
 		if all {
 			ws = d.Workspace.Uuid
 		}
-		fullStr := fmt.Sprintf(r, d.Label, d.ReleaseName, d.Id, ws)
-		fmt.Println(fullStr)
+
+		tab.AddRow([]string{d.Label, d.ReleaseName, d.Id, ws}, false)
 	}
+
+	tab.Print()
+
 	return nil
 }
 

--- a/deployment/deployment.go
+++ b/deployment/deployment.go
@@ -3,11 +3,8 @@ package deployment
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/astronomerio/astro-cli/config"
 	"github.com/astronomerio/astro-cli/houston"
-	"github.com/astronomerio/astro-cli/messages"
 	"github.com/astronomerio/astro-cli/pkg/httputil"
 	"github.com/astronomerio/astro-cli/pkg/jsonstr"
 	"github.com/astronomerio/astro-cli/pkg/printutil"
@@ -16,39 +13,44 @@ import (
 var (
 	http = httputil.NewHTTPClient()
 	api  = houston.NewHoustonClient(http)
+
+	tab = printutil.Table{
+		Padding: []int{30, 50, 50},
+		Header:  []string{"NAME", "RELEASE NAME", "DEPLOYMENT ID"},
+	}
 )
 
 func Create(label, ws string) error {
-	deployment, err := api.CreateDeployment(label, ws)
+	d, err := api.CreateDeployment(label, ws)
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf(messages.HOUSTON_DEPLOYMENT_CREATE_SUCCESS, deployment.Id)
 
 	c, err := config.GetCurrentContext()
 	if err != nil {
 		return err
 	}
+	tab.AddRow([]string{d.Label, d.ReleaseName, d.Id}, false)
+	tab.SuccessMsg = "\n Successfully created deployment. Deployment can be accessed at the following URLs \n" +
+		fmt.Sprintf("\n Airflow Dashboard: https://%s-airflow.%s", d.ReleaseName, c.Domain) +
+		fmt.Sprintf("\n Flower Dashboard: https://%s-flower.%s", d.ReleaseName, c.Domain)
 
-	cloudDomain := c.Domain
-	if len(cloudDomain) == 0 {
-		return errors.New("No domain set, re-authenticate.")
-	}
-
-	fmt.Printf("\n"+messages.EE_LINK_AIRFLOW+"\n", deployment.ReleaseName, cloudDomain)
-	fmt.Printf(messages.EE_LINK_FLOWER+"\n", deployment.ReleaseName, cloudDomain)
+	tab.Print()
 
 	return nil
 }
 
 func Delete(uuid string) error {
-	resp, err := api.DeleteDeployment(uuid)
+	_, err := api.DeleteDeployment(uuid)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf(messages.HOUSTON_DEPLOYMENT_DELETE_SUCCESS, resp.Id)
+	// TODO - add back in tab print once houston returns all relevant information
+	// tab.AddRow([]string{d.Label, d.ReleaseName, d.Id, d.Workspace.Uuid}, false)
+	// tab.SuccessMsg = "\n Successfully deleted deployment"
+	// tab.Print()
+	fmt.Println("\n Successfully deleted deployment")
 
 	return nil
 }
@@ -70,18 +72,13 @@ func List(ws string, all bool) error {
 		}
 	}
 
-	tab := printutil.Table{
-		Padding: []int{30, 50, 50, 50},
-		Header:  []string{"NAME", "RELEASE NAME", "DEPLOYMENT ID", "WORKSPACE"},
-	}
-
 	// Build rows
 	for _, d := range deployments {
 		if all {
 			ws = d.Workspace.Uuid
 		}
 
-		tab.AddRow([]string{d.Label, d.ReleaseName, d.Id, ws}, false)
+		tab.AddRow([]string{d.Label, d.ReleaseName, d.Id}, false)
 	}
 
 	tab.Print()
@@ -93,12 +90,14 @@ func List(ws string, all bool) error {
 func Update(deploymentId string, args map[string]string) error {
 	s := jsonstr.MapToJsonObjStr(args)
 
-	dep, err := api.UpdateDeployment(deploymentId, s)
+	d, err := api.UpdateDeployment(deploymentId, s)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf(messages.HOUSTON_DEPLOYMENT_UPDATE_SUCCESS, dep.Id)
+	tab.AddRow([]string{d.Label, d.ReleaseName, d.Id}, false)
+	tab.SuccessMsg = "\n Successfully updated deployment"
+	tab.Print()
 
 	return nil
 }

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -46,15 +46,9 @@ var (
 	COMPOSE_LINK_WEBSERVER       = "Airflow Webserver: http://localhost:8080/admin/"
 	COMPOSE_LINK_POSTGRES        = "Postgres Database: localhost:5432/postgres"
 
-	EE_LINK_AIRFLOW = "Airflow Dashboard: https://%s-airflow.%s"
-	EE_LINK_FLOWER  = "Flower Dashboard: https://%s-flower.%s"
-
 	HOUSTON_BASIC_AUTH_DISABLED           = "Basic authentication is disabled, conact administrator or defer back to oAuth"
 	HOUSTON_DEPLOYMENT_HEADER             = "Authenticated to %s \n\n"
 	HOUSTON_DEPLOYING_PROMPT              = "Deploying: %s\n"
-	HOUSTON_DEPLOYMENT_CREATE_SUCCESS     = "Successfully created %s\n"
-	HOUSTON_DEPLOYMENT_DELETE_SUCCESS     = "Successfully deleted %s\n"
-	HOUSTON_DEPLOYMENT_UPDATE_SUCCESS     = "Successfully updated deployment %s"
 	HOUSTON_NO_DEPLOYMENTS_ERROR          = "No airflow deployments found"
 	HOUSTON_SELECT_DEPLOYMENT_PROMPT      = "Select which airflow deployment you want to deploy to:"
 	HOUSTON_OAUTH_REDIRECT                = "Please visit the following URL, authenticate and paste token in next prompt\n"

--- a/messages/messages.go
+++ b/messages/messages.go
@@ -54,11 +54,9 @@ var (
 	HOUSTON_OAUTH_REDIRECT                = "Please visit the following URL, authenticate and paste token in next prompt\n"
 	HOUSTON_INVALID_DEPLOYMENT_KEY        = "Invalid deployment selection\n"
 	HOUSTON_NO_USERS                      = "There are no users to list or you don't have permissions to list users that do exist"
-	HOUSTON_WORKSPACE_CREATE_SUCCESS      = "Successfully created %s (%s)\n"
 	HOUSTON_WORKSPACE_DELETE_SUCCESS      = "Succesfully deleted %s (%s)\n"
 	HOUSTON_WORKSPACE_USER_ADD_SUCCESS    = "Successfully added user %s from workspace (%s)\n"
 	HOUSTON_WORKSPACE_USER_REMOVE_SUCCESS = "Successfully removed user %s from workspace (%s)\n"
-	HOUSTON_WORKSPACE_UPDATE_SUCCESS      = "Successfully updated workspace %s"
 
 	INPUT_PASSWORD    = "Password: "
 	INPUT_USERNAME    = "Username (leave blank for oAuth): "

--- a/pkg/printutil/printutil.go
+++ b/pkg/printutil/printutil.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 )
 
+// Table represents a table to be printed
 type Table struct {
 	// A slice of ints defining the padding for each column
 	Padding         []int
@@ -15,11 +16,8 @@ type Table struct {
 
 	// Truncate rows if they exceed padding length
 	Truncate bool
-	// 2d slice of strings, with each slice containing a row
-	// representation (nested slice of strings) of info to print
-	// Rows [][]string
 
-	// A place to store rows with padding correctly applied to them
+	// An array of row structs
 	Rows []Row
 
 	// A message to print after table has been printed
@@ -28,21 +26,21 @@ type Table struct {
 	// Optional message to print if no rows were passed to table
 	NoResultsMsg string
 
-	// Highlight a row with color
-
-	// Function which will eval whether to apply color to a row
+	// Len 2 array with elements representing ColorCode and ColorTrm respectively
 	ColorRowCode [2]string
 	// Function which will eval whether to apply color to a col
 	// ColorColCond    func(t *Table) (bool, error)
 	// ColorColCode [2]string
 }
 
+// Row represents a row to be printed
 type Row struct {
 	Raw      []string
 	Rendered string
 	Colored  bool
 }
 
+// AddRow is the preferred interface for adding a row to a table
 func (t *Table) AddRow(row []string, color bool) {
 	if len(t.RenderedPadding) == 0 {
 		p := t.GetPadding()
@@ -62,6 +60,7 @@ func (t *Table) AddRow(row []string, color bool) {
 	t.Rows = append(t.Rows, r)
 }
 
+// Print header __as well as__ rows
 func (t *Table) Print() error {
 	if len(t.Rows) == 0 && len(t.NoResultsMsg) != 0 {
 		fmt.Println(t.NoResultsMsg)
@@ -77,6 +76,7 @@ func (t *Table) Print() error {
 	return nil
 }
 
+// PrintHeader prints header
 func (t *Table) PrintHeader() {
 	if len(t.RenderedPadding) == 0 {
 		p := t.GetPadding()
@@ -89,6 +89,7 @@ func (t *Table) PrintHeader() {
 	fmt.Println(t.RenderedHeader)
 }
 
+// PrintRows prints rows with an "S"
 func (t *Table) PrintRows() {
 	for _, r := range t.Rows {
 		if r.Colored && len(t.ColorRowCode) == 2 {
@@ -99,6 +100,7 @@ func (t *Table) PrintRows() {
 	}
 }
 
+// GetPadding converts an array of ints into template padding for str fmting
 func (t *Table) GetPadding() string {
 	padStr := " "
 	for _, x := range t.Padding {
@@ -109,6 +111,10 @@ func (t *Table) GetPadding() string {
 	return padStr
 }
 
+// strSliceToInterface is a necessary conversion for passing
+// a series of strings as a variadic parameter to fmt.Sprintf()
+// ex
+// fmt.Sprintf(temp, strSliceToInterface(sliceofStrings)...)
 func strSliceToInterSlice(ss []string) []interface{} {
 	is := make([]interface{}, len(ss))
 	for i, v := range ss {

--- a/pkg/printutil/printutil.go
+++ b/pkg/printutil/printutil.go
@@ -1,0 +1,52 @@
+package printutil
+
+import (
+	"fmt"
+)
+
+type Table struct {
+	Padding      []int
+	Header       []string
+	Rows         [][]string
+	Length       int
+	RenderedRows []string
+	ColorCond    func()
+}
+
+func (t Table) PrintAll() error {
+	t.PrintHeader()
+	t.PrintRows()
+	return nil
+}
+
+func (t Table) PrintHeader() {
+	h := fmt.Sprintf(t.BuildPadding(), t.Header)
+
+	fmt.Println(h)
+}
+
+func (t Table) PrintRows() {
+	t.BuildRows()
+	for _, r := range t.RenderedRows {
+		fmt.Println(r)
+	}
+}
+
+func (t Table) BuildRows() {
+	p := t.BuildPadding()
+
+	for _, r := range t.Rows {
+		t.RenderedRows = append(t.RenderedRows, fmt.Sprintf(p, r))
+	}
+
+}
+
+func (t Table) BuildPadding() string {
+	padStr := ""
+	for _, x := range t.Padding {
+		temp := "%-%ss"
+		padStr += fmt.Sprintf(temp, x)
+	}
+
+	return padStr
+}

--- a/pkg/printutil/printutil.go
+++ b/pkg/printutil/printutil.go
@@ -5,16 +5,64 @@ import (
 )
 
 type Table struct {
-	Padding      []int
-	Header       []string
-	Rows         [][]string
-	RenderedRows []string
-	// ColorCond    func() bool
-	SuccessMsg   string
+	// A slice of ints defining the padding for each column
+	Padding         []int
+	RenderedPadding string
+
+	// Slice of strings representing column headers
+	Header         []string
+	RenderedHeader string
+
+	// Truncate rows if they exceed padding length
+	Truncate bool
+	// 2d slice of strings, with each slice containing a row
+	// representation (nested slice of strings) of info to print
+	// Rows [][]string
+
+	// A place to store rows with padding correctly applied to them
+	Rows []Row
+
+	// A message to print after table has been printed
+	SuccessMsg string
+
+	// Optional message to print if no rows were passed to table
 	NoResultsMsg string
+
+	// Highlight a row with color
+
+	// Function which will eval whether to apply color to a row
+	ColorRowCode [2]string
+	// Function which will eval whether to apply color to a col
+	// ColorColCond    func(t *Table) (bool, error)
+	// ColorColCode [2]string
 }
 
-func (t *Table) PrintAll() error {
+type Row struct {
+	Raw      []string
+	Rendered string
+	Colored  bool
+}
+
+func (t *Table) AddRow(row []string, color bool) {
+	if len(t.RenderedPadding) == 0 {
+		p := t.GetPadding()
+		t.RenderedPadding = p
+	}
+
+	ri := strSliceToInterSlice(row)
+
+	rr := fmt.Sprintf(t.RenderedPadding, ri...)
+
+	r := Row{
+		Raw:      row,
+		Rendered: rr,
+		Colored:  color,
+	}
+
+	t.Rows = append(t.Rows, r)
+}
+
+func (t *Table) Print() error {
 	if len(t.Rows) == 0 && len(t.NoResultsMsg) != 0 {
 		fmt.Println(t.NoResultsMsg)
 		return nil
@@ -30,33 +78,28 @@ func (t *Table) PrintAll() error {
 }
 
 func (t *Table) PrintHeader() {
-	header := strSliceToInterSlice(t.Header)
-	h := fmt.Sprintf(t.BuildPadding(), header...)
+	if len(t.RenderedPadding) == 0 {
+		p := t.GetPadding()
+		t.RenderedPadding = p
+	}
 
-	fmt.Println(h)
+	header := strSliceToInterSlice(t.Header)
+	t.RenderedHeader = fmt.Sprintf(t.RenderedPadding, header...)
+
+	fmt.Println(t.RenderedHeader)
 }
 
 func (t *Table) PrintRows() {
-	t.BuildRows()
-	for _, r := range t.RenderedRows {
-		fmt.Println(r)
-	}
-}
-
-func (t *Table) BuildRows() {
-	// TODO This function could trim strings down to length of padding
-	// at the index of the column
-	p := t.BuildPadding()
-	var rows []string
 	for _, r := range t.Rows {
-		row := strSliceToInterSlice(r)
-		rows = append(rows, fmt.Sprintf(p, row...))
+		if r.Colored && len(t.ColorRowCode) == 2 {
+			fmt.Println(t.ColorRowCode[0] + r.Rendered + t.ColorRowCode[1])
+		} else {
+			fmt.Println(r.Rendered)
+		}
 	}
-
-	t.RenderedRows = rows
 }
 
-func (t *Table) BuildPadding() string {
+func (t *Table) GetPadding() string {
 	padStr := " "
 	for _, x := range t.Padding {
 		temp := "%ds"

--- a/pkg/printutil/printutil.go
+++ b/pkg/printutil/printutil.go
@@ -8,45 +8,68 @@ type Table struct {
 	Padding      []int
 	Header       []string
 	Rows         [][]string
-	Length       int
 	RenderedRows []string
-	ColorCond    func()
+	// ColorCond    func() bool
+	SuccessMsg   string
+	NoResultsMsg string
 }
 
-func (t Table) PrintAll() error {
+func (t *Table) PrintAll() error {
+	if len(t.Rows) == 0 && len(t.NoResultsMsg) != 0 {
+		fmt.Println(t.NoResultsMsg)
+		return nil
+	}
+
 	t.PrintHeader()
 	t.PrintRows()
+
+	if len(t.SuccessMsg) != 0 {
+		fmt.Println(t.SuccessMsg)
+	}
 	return nil
 }
 
-func (t Table) PrintHeader() {
-	h := fmt.Sprintf(t.BuildPadding(), t.Header)
+func (t *Table) PrintHeader() {
+	header := strSliceToInterSlice(t.Header)
+	h := fmt.Sprintf(t.BuildPadding(), header...)
 
 	fmt.Println(h)
 }
 
-func (t Table) PrintRows() {
+func (t *Table) PrintRows() {
 	t.BuildRows()
 	for _, r := range t.RenderedRows {
 		fmt.Println(r)
 	}
 }
 
-func (t Table) BuildRows() {
+func (t *Table) BuildRows() {
+	// TODO This function could trim strings down to length of padding
+	// at the index of the column
 	p := t.BuildPadding()
-
+	var rows []string
 	for _, r := range t.Rows {
-		t.RenderedRows = append(t.RenderedRows, fmt.Sprintf(p, r))
+		row := strSliceToInterSlice(r)
+		rows = append(rows, fmt.Sprintf(p, row...))
 	}
 
+	t.RenderedRows = rows
 }
 
-func (t Table) BuildPadding() string {
-	padStr := ""
+func (t *Table) BuildPadding() string {
+	padStr := " "
 	for _, x := range t.Padding {
-		temp := "%-%ss"
-		padStr += fmt.Sprintf(temp, x)
+		temp := "%ds"
+		padStr += "%-" + fmt.Sprintf(temp, x)
 	}
 
 	return padStr
+}
+
+func strSliceToInterSlice(ss []string) []interface{} {
+	is := make([]interface{}, len(ss))
+	for i, v := range ss {
+		is[i] = v
+	}
+	return is
 }

--- a/user/user.go
+++ b/user/user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/astronomerio/astro-cli/houston"
-	"github.com/astronomerio/astro-cli/messages"
 	"github.com/astronomerio/astro-cli/pkg/httputil"
 	"github.com/astronomerio/astro-cli/pkg/input"
 )
@@ -42,24 +41,6 @@ func Create(email string) error {
 
 	msg = fmt.Sprintf(msg, email, loginMsg)
 	fmt.Println(msg)
-
-	return nil
-}
-
-func List() error {
-	r, err := api.GetUserAll()
-	if err != nil {
-		return err
-	}
-
-	if len(r) == 0 {
-		fmt.Println(messages.HOUSTON_NO_USERS)
-	}
-
-	for _, u := range r {
-		rowTmp := "Username: %s\nId: %s\nStatus: %s\n\n"
-		fmt.Printf(rowTmp, u.Username, u.Uuid, u.Status)
-	}
 
 	return nil
 }

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -10,6 +10,7 @@ import (
 	"github.com/astronomerio/astro-cli/messages"
 	"github.com/astronomerio/astro-cli/pkg/httputil"
 	"github.com/astronomerio/astro-cli/pkg/jsonstr"
+	"github.com/astronomerio/astro-cli/pkg/printutil"
 )
 
 var (
@@ -29,9 +30,11 @@ func Create(label, desc string) error {
 
 // List all workspaces
 func List() error {
-	r := "  %-44s %-50s"
-	colorFmt := "\033[33;m"
-	colorTrm := "\033[0m"
+	tab := printutil.Table{
+		Padding:      []int{44, 50},
+		Header:       []string{"NAME", "UUID"},
+		ColorRowCode: [2]string{"\033[33;m", "\033[0m"},
+	}
 
 	ws, err := api.GetWorkspaceAll()
 	if err != nil {
@@ -39,20 +42,18 @@ func List() error {
 	}
 
 	c, err := config.GetCurrentContext()
-
-	head := fmt.Sprintf(r, "NAME", "UUID")
-	fmt.Println(head)
 	for _, w := range ws {
 		name := w.Label
 		workspace := w.Uuid
 
-		fullStr := fmt.Sprintf(r, name, workspace)
 		if c.Workspace == w.Uuid {
-			fullStr = colorFmt + fullStr + colorTrm
+			tab.AddRow([]string{name, workspace}, true)
+		} else {
+			tab.AddRow([]string{name, workspace}, false)
 		}
-
-		fmt.Println(fullStr)
 	}
+
+	tab.Print()
 
 	return nil
 }


### PR DESCRIPTION
This PR implements a new printutil.tabprint lib which allows for cleaner and declarative management of the tab printing which is used throughout the CLI.

It also implements some fixes for resource `update` validation errors